### PR TITLE
Add tags

### DIFF
--- a/db/migrations/20190222095114_tags.js
+++ b/db/migrations/20190222095114_tags.js
@@ -1,0 +1,20 @@
+exports.up = async function (knex, Promise) {
+  try {
+    await knex.schema.createTable('tags', t => {
+      t.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+      t.string('name').notNullable()
+    })
+    return knex.schema.createTable('reports_tags', t => {
+      t.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+      t.uuid('report_id').references('reports.id').onDelete('cascade')
+      t.uuid('tag_id').references('tags.id').onDelete('cascade')
+    })
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+exports.down = async function (knex, Promise) {
+  await knex.schema.dropTable('reports_tags')
+  return knex.schema.dropTable('tags')
+}


### PR DESCRIPTION
Close #1 

cc: @dereklieu 

Once this is merged, I'll deploy to the AWS database.
- Getting all tags: `/tags`
- Adding a new tag: POST to `/tags` with `{name: 'new tag'}`
- Associating a report with a tag: POST to `/reports_tags` with `{ report_id: RID, tag_id: TID }`
- Getting all reports with a given tag: GET `/tags?id=eq.TID&select=reports(id)`
- Getting all tags for a given report: GET `/reports?id=eq.RID&select=id,tags(name)`

 (note that the last two seem a little odd because you are hitting the endpoint for the "wrong" thing but it's needed to filter on the correct field)