### PR TITLE
Add author column, limit to jwt writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .kes/.env
 .kes/cloudformation.yml
+api.conf

--- a/createroles.sql
+++ b/createroles.sql
@@ -1,0 +1,7 @@
+create role webuser nologin;
+grant webuser to nethopesitrep;
+
+grant usage on schema public to webuser;
+grant all on public.reports to webuser;
+grant all on public.reports_tags to webuser;
+grant all on public.tags to webuser;

--- a/db/migrations/20190224134517_author.js
+++ b/db/migrations/20190224134517_author.js
@@ -1,0 +1,18 @@
+exports.up = async function (knex, Promise) {
+  try {
+    await knex.raw(`
+      BEGIN TRANSACTION READ WRITE;
+      SET LOCAL "request.jwt.claim.email" = 'admin@developmentseed.org';
+      ALTER TABLE reports ADD COLUMN author character varying(255) NOT NULL DEFAULT current_setting('request.jwt.claim.email') CHECK (author::text = current_setting('request.jwt.claim.email') AND current_setting('request.jwt.claim.email') IS NOT NULL);
+      COMMIT;
+    `)
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+exports.down = async function (knex, Promise) {
+  return knex.schema.table('reports', t => {
+    t.dropColumn('author')
+  })
+}


### PR DESCRIPTION
@dereklieu tested this all locally and it seems to work but it imposes some restrictions on JWT tokens so I'll hold on deploying to remote until you're ready. Short version:
- Adds an `author` field to `reports` for the email address of the report author.
- The field can't be null and it defaults to the `email` claim sent in the JWT token. It will error if you try to send your own `email` property on the report (unless it's exactly equal to the JWT email) or if you don't have that claim in your JWT token.
- Because the field can't be null, the seed reports have an author value of `admin@developmentseed.org`